### PR TITLE
Update the last accessed time for a URL on access

### DIFF
--- a/src/__tests__/apiTest.ts
+++ b/src/__tests__/apiTest.ts
@@ -80,16 +80,19 @@ test('ShortenedUrl.lastAccessedTime is updated on request', async () => {
   // Access the URL
   await sleep(1000);
   await fetch(shortenedUrl.short);
+  await sleep(1000);
 
   // Verify the last accessed time is updated
   const shortResponse = await fetch(`${API}/url/${shortenedUrl.id}`);
   const shortResponseUrl: IShortenedUrl = await shortResponse.json();
-  shortResponseUrl.created = new Date(shortenedUrl.created);
-  shortResponseUrl.lastAccessed = new Date(shortenedUrl.lastAccessed);
+  shortResponseUrl.created = new Date(shortResponseUrl.created);
+  shortResponseUrl.lastAccessed = new Date(shortResponseUrl.lastAccessed);
+
   expect(shortResponseUrl.created).toEqual(shortenedUrl.created);
+  expect(shortResponseUrl.accessCount).toEqual(1);
   expect(shortResponseUrl.lastAccessed.getTime())
-    .toBeGreaterThan(shortenedUrl.lastAccessed.getTime());
-})
+    .toBeGreaterThan(shortenedUrl.created.getTime());
+});
 
 test('Can delete a URL', async () => {
   const body = { url: 'https://www.google.com/' };

--- a/src/entity/IShortenedUrl.ts
+++ b/src/entity/IShortenedUrl.ts
@@ -4,6 +4,7 @@ interface IShortenedUrl {
   short: string;
   created: Date;
   lastAccessed: Date;
+  accessCount: number;
 }
 
 export default IShortenedUrl;

--- a/src/entity/ShortenedUrl.ts
+++ b/src/entity/ShortenedUrl.ts
@@ -30,11 +30,8 @@ export default class ShortenedUrl implements IShortenedUrl {
   @UpdateDateColumn()
   lastAccessed!: Date;
 
-  @OneToMany('URLLogEntry', 'url', {
-    onDelete: 'CASCADE',
-  })
-  @JoinColumn({ name: 'urlId' })
-  logEntries?: IURLLogEntry[];
+  @Column({ default: 0 })
+  accessCount!: number;
 
   short!: string;
 
@@ -42,6 +39,10 @@ export default class ShortenedUrl implements IShortenedUrl {
   @AfterInsert()
   getShort(): void {
     this.short = `${process.env.BASE_URL}/${this.id}`;
+  }
+
+  async save(): Promise<void> {
+    await getRepository(ShortenedUrl).save(this);
   }
 
   static async getForId(urlId: string): Promise<ShortenedUrl> {

--- a/src/handlers.ts
+++ b/src/handlers.ts
@@ -22,6 +22,8 @@ export const getShortenedUrl = async (req: Request, res: Response): Promise<void
   }
 
   res.redirect(shortenedUrl.original);
+  shortenedUrl.accessCount += 1;
+  shortenedUrl.save();
 };
 
 export const urlStatsHandler = async (req: Request, res: Response): Promise<void> => {


### PR DESCRIPTION
The `ShortenedUrl.lastAccessedTime` is now updated when a ShortenedUrl is visited. Also changes ShortenedUrl to have an `accessCount` property rather than storing a log of all visits.