### PR TITLE
Added remote trigger for building the ezzizzle/shortener-deploy repo

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -78,3 +78,10 @@ jobs:
           tag_with_ref: true
           tags: latest
           add_git_labels: true
+
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: ezzizzle/shortener-deploy
+          event-type: shortener-build


### PR DESCRIPTION
Now when this repo builds on `main`, it triggers a deployment on the [ezzizzle/shortener-deploy](https://github.com/ezzizzle/shortener-deploy) repo